### PR TITLE
Fix FindWhere syntax error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-twitterstream-script",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Hubot Twitter Streaming",
   "author": "Christophe Hamerling <christophe.hamerling@ow2.org>",
   "homepage": "http://github.com/chamerling/hubot-twitterstream-script",

--- a/twitterstream.js
+++ b/twitterstream.js
@@ -70,7 +70,7 @@ module.exports = function(robot) {
     });
     if (stream != undefined) {
       stream.fn.destroy();
-      streams = _.without(streams, _findWhere(streams, stream));
+      streams = _.without(streams, _.findWhere(streams, stream));
       msg.send('I stopped watching ' + tag);
     } else {
       msg.send('I do not known such tag.');


### PR DESCRIPTION
There was a syntax error in twitterstream.js [here](https://github.com/chamerling/hubot-twitterstream-script/compare/master...neufeldtech:master#diff-45fe140df8f2d012976d2a88d356a76cL73). This PR fixes it.